### PR TITLE
Adds ibmcloud_api_key to global scope

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -56,3 +56,5 @@ versions:
       scope: global
     - name : private_endpoint
       scope: global
+    - name: ibmcloud_api_key
+      scope: global


### PR DESCRIPTION
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>